### PR TITLE
Added WebP and AVIF support

### DIFF
--- a/clean-image-filenames.php
+++ b/clean-image-filenames.php
@@ -42,6 +42,8 @@ class CleanImageFilenames {
 			'image/pjpeg',
 			'image/png',
 			'image/tiff',
+			'image/avif',
+			'image/webp',
 		),
 	);
 


### PR DESCRIPTION
WordPress now [supports both WebP and AVIF](https://make.wordpress.org/core/2024/02/23/wordpress-6-5-adds-avif-support/) image formats by default.